### PR TITLE
Fix achievements metrics and improve README layout

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -68,6 +68,8 @@ jobs:
           base: ""
           config_timezone: Asia/Bangkok
           plugin_achievements: yes
+          plugin_achievements_display: compact
+          plugin_achievements_ignored: projects
 
       - uses: lowlighter/metrics@latest
         with:

--- a/README.md
+++ b/README.md
@@ -5,27 +5,28 @@
 ---
 
 ## 📊 Metrics
-[![Main Metrics](https://raw.githubusercontent.com/JNX03/JNX03/main/github-metrics.svg)](https://github.com/lowlighter/metrics)
 
-### Additional Metrics
-
-<!-- Isometric commit calendar -->
-![Commit Calendar](./github-metrics.isocalendar.svg)
-
-<!-- Most used languages -->
-![Languages](./github-metrics.languages.svg)
-
-<!-- Lines of code changed -->
-![Lines of Code](./github-metrics.lines.svg)
-
-<!-- Achievements -->
-![Achievements](./github-metrics.achievements.svg)
-
-<!-- Recently starred repositories -->
-![Stargazers](./github-metrics.stargazers.svg)
-
-<!-- Followers information -->
-![Followers](./github-metrics.followers.svg)
+<table>
+  <tr>
+    <td colspan="2">
+      <a href="https://github.com/lowlighter/metrics">
+        <img src="https://raw.githubusercontent.com/JNX03/JNX03/main/github-metrics.svg" alt="Main metrics" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td><img src="./github-metrics.isocalendar.svg" alt="Commit Calendar" /></td>
+    <td><img src="./github-metrics.languages.svg" alt="Languages" /></td>
+  </tr>
+  <tr>
+    <td><img src="./github-metrics.lines.svg" alt="Lines of Code" /></td>
+    <td><img src="./github-metrics.achievements.svg" alt="Achievements" /></td>
+  </tr>
+  <tr>
+    <td><img src="./github-metrics.stargazers.svg" alt="Stargazers" /></td>
+    <td><img src="./github-metrics.followers.svg" alt="Followers" /></td>
+  </tr>
+</table>
 
 ---
 


### PR DESCRIPTION
## Summary
- tweak metrics workflow to ignore deprecated projects data for achievements plugin
- revamp README metrics section with table layout

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d35f8fe288321b72d409a9224897e