### PR TITLE
Change metrics workflow to run weekly

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -2,7 +2,8 @@ name: Metrics
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    # Run every Monday at 00:00 UTC instead of every day
+    - cron: "0 0 * * 1"
   workflow_dispatch:
   push:
     branches: [main]


### PR DESCRIPTION
## Summary
- run metrics workflow only once a week (every Monday)

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68839aad535c832196b9f1fb4edeea4d